### PR TITLE
Change source installation instructions to use a virtualenv

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -25,24 +25,27 @@
                 <ol>
                     <li>Install requirements:
                         <ul>
-                            <li>Ubuntu/Debian: <pre>sudo apt install python3 python3-pip git</pre></li>
+                            <li>Ubuntu/Debian: <pre>sudo apt install python3 python3-pip python3-virtualenv git</pre></li>
                             <li>Fedora (comes with Python 3 preinstalled): <pre>sudo dnf install git</pre></li>
-                            <li>Arch: <pre>sudo pacman -S python python-pip git</pre></li>
+                            <li>Arch: <pre>sudo pacman -S python python-pip python-virtualenv git</pre></li>
                             <li>OS X: Download <a href="https://python.org/downloads">Python 3 here</a></li>
                         </ul>
                     </li>
                     <li>
                         Clone repository:
                         <pre>git clone https://github.com/xSke/Garlium
-    cd Garlium</pre>
+cd Garlium</pre>
                     </li>
                     <li>
+                        Create a virtual environment:
+                        <pre>virtualenv ./ --python=python3</pre>
+                    <li>
                         Install Garlium + dependencies:
-                        <pre>python3 setup.py install</pre>
+                        <pre>bin/python3 setup.py install</pre>
                     </li>
                     <li>
                         Run Garlium:
-                        <pre>python3 ./garlium</pre>
+                        <pre>bin/python3 ./garlium</pre>
                     </li>
                 </ol>
             </p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,7 +28,7 @@
                             <li>Ubuntu/Debian: <pre>sudo apt install python3 python3-pip python3-virtualenv git</pre></li>
                             <li>Fedora (comes with Python 3 preinstalled): <pre>sudo dnf install git</pre></li>
                             <li>Arch: <pre>sudo pacman -S python python-pip python-virtualenv git</pre></li>
-                            <li>OS X: Download <a href="https://python.org/downloads">Python 3 here</a></li>
+                            <li>OS X: Download <a href="https://python.org/downloads">Python 3 here</a>, then: <pre>sudo pip install virtualenv</pre></li>
                         </ul>
                     </li>
                     <li>


### PR DESCRIPTION
Because it would be bad if we accidentally overwrote dependencies for another Python program on someone's system.