### PR TITLE
Add install from AUR instructions

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,11 @@
                         <ul>
                             <li>Ubuntu/Debian: <pre>sudo apt install python3 python3-pip python3-virtualenv git</pre></li>
                             <li>Fedora (comes with Python 3 preinstalled): <pre>sudo dnf install git</pre></li>
-                            <li>Arch: <pre>sudo pacman -S python python-pip python-virtualenv git</pre></li>
+                            <li>Arch: <pre>sudo pacman -S python python-pip python-virtualenv git</pre>
+                                <ul>
+                                    <li>Or install Garlium from AUR: <pre>yaourt -S garlium-git</pre></li>
+                                </ul>
+                            </li>
                             <li>OS X: Download <a href="https://python.org/downloads">Python 3 here</a>, then: <pre>sudo pip install virtualenv</pre></li>
                         </ul>
                     </li>


### PR DESCRIPTION
I created an AUR package for easy installation on Arch. If you want to add this to the official page, that would be great.

https://aur.archlinux.org/packages/garlium-git/